### PR TITLE
fix: sort articles by publish time

### DIFF
--- a/kaiyuanshe/controllers/article.go
+++ b/kaiyuanshe/controllers/article.go
@@ -18,6 +18,7 @@ func CreateArticle(c *gin.Context) {
 		return
 	}
 
+	now := time.Now()
 	var article = models.Article{
 		Title:       req.Title,
 		Description: req.Desc,
@@ -31,6 +32,7 @@ func CreateArticle(c *gin.Context) {
 		Author:      req.Author,
 		Translator:  req.Translator,
 		Editor:      req.Editor,
+		PublishTime: &now,
 	}
 
 	uid, ok := c.Get("uid")

--- a/kaiyuanshe/models/article.go
+++ b/kaiyuanshe/models/article.go
@@ -101,9 +101,9 @@ func QueryArticles(filter ArticleFilter) ([]Article, int64, error) {
 
 	// 排序
 	if filter.OrderDesc {
-		query = query.Order("publish_time desc")
+		query = query.Order("publish_time DESC NULLS LAST").Order("created_at DESC")
 	} else {
-		query = query.Order("publish_time asc")
+		query = query.Order("publish_time ASC NULLS LAST").Order("created_at ASC")
 	}
 
 	// 分页


### PR DESCRIPTION
## Summary
- set publish time when creating articles so new posts have a sortable timestamp
- sort article queries by publish_time with NULLS LAST and use created_at as a stable fallback

## Test Plan
- /Users/hanlinye/.local/go/bin/go test ./... from kaiyuanshe/
- git diff --check

## Risk
- Low. This only changes article create/query ordering and keeps existing ascending/descending behavior.