### PR TITLE
style(home): refine responsive hero layout(#53)

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -114,8 +114,13 @@
     "hero": {
       "title": "KaiYuanShe",
       "subtitle": "Rooted in China, contributing globally.",
-      "heroHighlight": "Rooted in China, contributing globally,",
-      "heroSubtext": "promoting open source"
+      "heroHighlight": "Rooted in China · Contributing globally",
+      "heroSubtext": "Advancing open source as a way of life for a new era",
+      "heroEmphasis": "open source",
+      "heroKeywordChina": "China",
+      "heroKeywordGlobal": "globally",
+      "heroMicroline": "ROOTED IN CHINA · CONTRIBUTING GLOBALLY · OPEN SOURCE AS A WAY OF LIFE",
+      "heroCta": "About KaiYuanShe"
     },
     "carousel": {
       "viewDetails": "View Details"

--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -114,8 +114,13 @@
     "hero": {
       "title": "开源社",
       "subtitle": "立足中国，贡献全球，推动开源成为新时代生活方式",
-      "heroHighlight": "立足中国，贡献全球，",
-      "heroSubtext": "推动开源成为新时代生活方式。"
+      "heroHighlight": "立足中国 · 贡献全球",
+      "heroSubtext": "推动开源成为新时代生活方式",
+      "heroEmphasis": "开源",
+      "heroKeywordChina": "中国",
+      "heroKeywordGlobal": "全球",
+      "heroMicroline": "ROOTED IN CHINA · CONTRIBUTING GLOBALLY · OPEN SOURCE AS A WAY OF LIFE",
+      "heroCta": "了解开源社"
     },
     "carousel": {
       "viewDetails": "查看详情"

--- a/locales/zh-TW/common.json
+++ b/locales/zh-TW/common.json
@@ -113,8 +113,13 @@
     "hero": {
       "title": "開源社",
       "subtitle": "立足中國，貢獻全球，推動開源成為新時代生活方式",
-      "heroHighlight": "立足中國，貢獻全球，",
-      "heroSubtext": "推動開源成為新時代生活方式。"
+      "heroHighlight": "立足中國 · 貢獻全球",
+      "heroSubtext": "推動開源成為新時代生活方式",
+      "heroEmphasis": "開源",
+      "heroKeywordChina": "中國",
+      "heroKeywordGlobal": "全球",
+      "heroMicroline": "ROOTED IN CHINA · CONTRIBUTING GLOBALLY · OPEN SOURCE AS A WAY OF LIFE",
+      "heroCta": "了解開源社"
     },
     "carousel": {
       "viewDetails": "查看詳情"

--- a/src/components/home/hero/Hero.module.css
+++ b/src/components/home/hero/Hero.module.css
@@ -1,281 +1,211 @@
-/* Hero Section */
 .hero {
   position: relative;
-  padding: 4rem 1rem;
-  padding-top: 6rem;
+  min-height: min(55svh, 620px);
+  padding: 96px 1rem 72px;
   overflow: hidden;
-  background-size: 200% 200%;
-  animation: gradientShift 12s ease-in-out infinite;
-  min-height: 45vh;
-}
-
-@media (max-width: 768px) {
-  .hero {
-    padding: 3rem 1rem;
-    padding-top: 4.5rem;
-  }
-
-  .heroTitle {
-    font-size: clamp(2rem, 8vw, 2.5rem);
-    margin-bottom: 1rem;
-  }
-
-  .heroButtons {
-    flex-direction: column;
-    gap: 0.75rem;
-  }
-}
-
-@media (max-width: 480px) {
-  .hero {
-    padding: 2rem 0.5rem;
-    padding-top: 3rem;
-  }
-
-  .heroTitle {
-    font-size: clamp(1.8rem, 8vw, 2.2rem);
-    margin-bottom: 0.75rem;
-  }
-
-  .heroContent {
-    padding: 0 0.5rem;
-  }
-
-  .heroSubtitle {
-    margin-bottom: 1.5rem;
-  }
+  display: flex;
+  align-items: center;
 }
 
 .heroBackground {
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-}
-
-.heroGradient {
-  position: absolute;
-  inset: 0;
-  background-image: url('/welcome-bg.png');
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-color: #0e738a57;
-}
-
-.heroSubtitle {
-  height: 56vh;
-  font-family: 'Noto Sans SC', sans-serif;
-  font-style: normal;
-  font-weight: 600;
-  font-size: 70px;
-  line-height: 5rem;
-  display: flex;
-  align-items: center;
-  text-align: center;
-  color: #333333;
-  margin-bottom: 2rem;
-  justify-content: center;
+  width: 100%;
+  max-width: 1200px;
   margin: 0 auto;
 }
 
-.heroHighlight {
-  margin-bottom: 2.2rem;
-  color: #333333;
-  font-weight: 500;
-}
-
-.heroDown {
+.heroOrnament {
+  width: 100%;
+  max-width: 960px;
+  margin-bottom: 28px;
   display: flex;
-  justify-content: center;
   align-items: center;
-  margin-top: 200px;
-  animation: fadeInUp 1.5s ease-out;
-  cursor: pointer;
+  gap: 12px;
 }
 
-.heroArrow {
-  color: #333333;
-  animation: bounce 2s infinite ease-in-out;
-  transition: all 0.3s ease;
-  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
+.heroOrnament span {
+  width: 52px;
+  height: 2px;
+  display: block;
+  background: var(--primary-900);
+  opacity: 0.72;
 }
 
-.heroArrow:hover {
-  transform: scale(1.1);
-  color: #555555;
-  filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.3));
+.heroOrnament span:last-child {
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--primary-900);
+  border-radius: 50%;
+  background: transparent;
+  opacity: 0.72;
 }
 
-/* 淡入向上动画 */
-@keyframes fadeInUp {
-  0% {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-  100% {
-    opacity: 1;
-    transform: translateY(0);
-  }
+.heroSubtitle {
+  width: 100%;
+  max-width: 960px;
+  color: var(--primary-950);
+  text-align: left;
+  font-family: "Noto Sans SC", Arial, Helvetica, sans-serif;
 }
 
-/* 上下弹跳动画 */
-@keyframes bounce {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(10px);
-  }
+.heroTitle {
+  max-width: 960px;
+  margin: 0;
+  color: var(--primary-950);
+  font-size: clamp(28px, calc(2.2vw + 20px), 60px);
+  font-weight: 700;
+  line-height: 1.35;
+  letter-spacing: 0;
+  text-wrap: balance;
+  overflow-wrap: anywhere;
 }
 
-/* 渐变背景动画 */
-@keyframes gradientShift {
-  0% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
-  }
+.heroLine {
+  display: block;
 }
 
-/* 响应式设计 */
-@media (max-width: 768px) {
-  .heroDown {
-    margin-top: 150px;
-  }
-
-  .heroArrow {
-    transform: scale(0.8);
-  }
-
-  .heroArrow:hover {
-    transform: scale(0.9);
-  }
+.heroEmphasis {
+  background: linear-gradient(110deg, var(--primary-900), var(--primary-600));
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  font-weight: 900;
 }
 
-.heroButtons:hover a {
-  color: #333 !important;
+.heroMicroline {
+  margin: 22px 0 0;
+  color: var(--primary-900);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.5;
+  letter-spacing: 2.5px;
+  opacity: 0.56;
+  text-transform: uppercase;
 }
 
 .heroPrimaryButton {
-  background: #fefefe;
-  color: #333;
-  border: none;
-  padding: 0.75rem 3rem;
-  border-radius: 2rem;
-  font-size: 1rem;
-  font-weight: 600;
-  box-shadow: 0 4px 12px rgba(110, 84, 255, 0.3);
-  transition: all 0.3s ease;
-  cursor: pointer;
-  display: flex;
+  width: fit-content;
+  min-height: 44px;
+  margin-top: 24px;
+  padding: 11px 18px;
+  border: 1px solid var(--primary-900);
+  border-radius: 6px;
+  background: var(--primary-900);
+  color: var(--button-primary-text);
+  display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  backdrop-filter: blur(10px);
-  text-decoration: none;
+  justify-content: center;
+  gap: 10px;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.2s ease;
 }
 
-.heroSecondaryButton {
-  background: #999;
-  color: #333;
-  border: 1px solid rgba(110, 84, 255, 0.2);
-  padding: 0.75rem 3rem;
-  border-radius: 2rem;
-  font-size: 1rem;
-  font-weight: 600;
-  box-shadow: 0 4px 12px rgba(110, 84, 255, 0.15);
-  transition: all 0.3s ease;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  backdrop-filter: blur(10px);
+.heroPrimaryButton:hover {
+  border-color: var(--primary-700);
+  background: var(--primary-700);
+  color: var(--button-primary-text);
+}
+
+.heroPrimaryButton:active {
+  transform: translateY(1px);
+}
+
+.heroPrimaryButton:focus-visible {
+  outline: 3px solid var(--primary-200);
+  outline-offset: 3px;
 }
 
 .buttonIcon {
-  width: 1.5rem;
-  height: 1.5rem;
-  color: inherit;
-  transition: all 0.3s ease;
-}
-
-.heroPrimaryButton .buttonIcon {
-  color: #333;
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  stroke-width: 2;
+  transition: transform 0.2s ease;
 }
 
 .heroPrimaryButton:hover .buttonIcon {
-  color: #333;
-}
-
-.heroSecondaryButton .buttonIcon {
-  color: #333;
-}
-
-/* ���	� */
-@media (max-width: 768px) {
-  .heroButtons {
-    flex-direction: column;
-    gap: 0.75rem;
-    margin-top: 2rem;
-  }
-
-  .heroPrimaryButton,
-  .heroSecondaryButton {
-    width: 100%;
-    max-width: 280px;
-    justify-content: center;
-  }
-}
-
-@media (max-width: 480px) {
-  .heroButtons {
-    gap: 0.5rem;
-    margin-top: 2.5rem;
-  }
-
-  .heroPrimaryButton,
-  .heroSecondaryButton {
-    padding: 0.6rem 1.2rem;
-    font-size: 0.9rem;
-    max-width: 250px;
-  }
+  transform: translateX(3px);
 }
 
 @media (max-width: 1024px) {
-  .heroSubtitle {
-    width: 100%;
-    max-width: 650px;
-    font-size: 32px;
-    line-height: 42px;
-    height: auto;
-    padding: 0 1rem;
-    margin-top: 6rem;
-    margin-bottom: 2.5rem;
+  .hero {
+    padding-top: 80px;
+    padding-bottom: 64px;
+  }
+
+  .heroTitle,
+  .heroSubtitle,
+  .heroOrnament {
+    max-width: 780px;
   }
 }
 
 @media (max-width: 768px) {
-  .heroSubtitle {
-    font-size: 26px;
-    line-height: 36px;
-    /* max-width: 500px; */
-    width: 100%;
-    margin-top: 8rem;
-    margin-bottom: 3rem;
+  .hero {
+    min-height: auto;
+    padding: 32px 14px 28px;
+    align-items: flex-start;
+  }
+
+  .heroTitle,
+  .heroSubtitle,
+  .heroOrnament {
+    max-width: 100%;
+  }
+
+  .heroOrnament {
+    margin-bottom: 16px;
+    gap: 10px;
+  }
+
+  .heroOrnament span {
+    width: 36px;
+    height: 1px;
+  }
+
+  .heroOrnament span:last-child {
+    width: 16px;
+    height: 16px;
+    border-width: 1px;
+  }
+
+  .heroMicroline {
+    margin-top: 14px;
+    font-size: 9px;
+    letter-spacing: 1.8px;
+  }
+
+  .heroPrimaryButton {
+    margin-top: 18px;
   }
 }
 
-@media (max-width: 480px) {
-  .heroSubtitle {
-    font-size: 22px;
-    line-height: 30px;
-    /* max-width: 320px; */
-    width: 100%;
-    margin-top: 10rem;
-    margin-bottom: 3.5rem;
+@media (max-width: 350px) {
+  .hero {
+    padding: 28px 12px 24px;
+  }
+
+  .heroOrnament span {
+    width: 24px;
+  }
+
+  .heroTitle {
+    font-size: 28px;
+  }
+
+  .heroMicroline {
+    letter-spacing: 1.2px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .heroPrimaryButton,
+  .buttonIcon {
+    transition: none;
   }
 }

--- a/src/components/home/hero/Hero.tsx
+++ b/src/components/home/hero/Hero.tsx
@@ -1,34 +1,77 @@
-import { ChevronDown } from 'lucide-react' 
-import styles from './Hero.module.css'
-import { useTranslation } from '../../../hooks/useTranslation'
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import styles from "./Hero.module.css";
+import { useTranslation } from "../../../hooks/useTranslation";
 
 export default function Hero() {
-  const { t } = useTranslation()
-  
+  const { t } = useTranslation();
+  const highlightText = t("homepage.hero.heroHighlight");
+  const highlightTerms = [
+    t("homepage.hero.heroKeywordChina"),
+    t("homepage.hero.heroKeywordGlobal"),
+  ];
+  const heroText = t("homepage.hero.heroSubtext");
+  const emphasis = t("homepage.hero.heroEmphasis");
+  const escapeRegExp = (value: string) =>
+    value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const highlightPattern = new RegExp(
+    `(${highlightTerms.map(escapeRegExp).join("|")})`,
+    "giu",
+  );
+  const emphasisIndex = heroText
+    .toLocaleLowerCase()
+    .indexOf(emphasis.toLocaleLowerCase());
+  const hasEmphasis = emphasisIndex >= 0;
+  const textBeforeEmphasis = hasEmphasis
+    ? heroText.slice(0, emphasisIndex)
+    : heroText;
+  const textAfterEmphasis = hasEmphasis
+    ? heroText.slice(emphasisIndex + emphasis.length)
+    : "";
+
   return (
     <section className={styles.hero}>
       <div className={styles.heroBackground}>
+        <div className={styles.heroOrnament} aria-hidden="true">
+          <span />
+          <span />
+        </div>
         <div className={styles.heroSubtitle}>
-          <div>
-            <p className={styles.heroHighlight}>{t('homepage.hero.heroHighlight')}</p>
-            <p>{t('homepage.hero.heroSubtext')}</p>
-          </div>
-        </div>
-
-        <div className={styles.heroDown}>
-           <ChevronDown className={styles.heroArrow} size={100}/>
-        </div>
-        {/* <div className={styles.heroButtons}>
-          <Link href="https://kaiyuanshe.feishu.cn/wiki/wikcn749HAOCD2dwaNq4dOC67db" target='_blank' className={styles.heroPrimaryButton}>
-            <Globe className={styles.buttonIcon} />
-            了解 开源社
+          <h1 className={styles.heroTitle}>
+            <span className={styles.heroLine}>
+              {highlightText.split(highlightPattern).map((part, index) =>
+                highlightTerms.some(
+                  (term) =>
+                    term.toLocaleLowerCase() === part.toLocaleLowerCase(),
+                ) ? (
+                  <strong
+                    className={styles.heroEmphasis}
+                    key={`${part}-${index}`}
+                  >
+                    {part}
+                  </strong>
+                ) : (
+                  <span key={`${part}-${index}`}>{part}</span>
+                ),
+              )}
+            </span>
+            <span className={styles.heroLine}>
+              {textBeforeEmphasis}
+              {hasEmphasis && (
+                <strong className={styles.heroEmphasis}>{emphasis}</strong>
+              )}
+              {textAfterEmphasis}
+            </span>
+          </h1>
+          <p className={styles.heroMicroline}>
+            {t("homepage.hero.heroMicroline")}
+          </p>
+          <Link href="/about" className={styles.heroPrimaryButton}>
+            {t("homepage.hero.heroCta")}
+            <ArrowRight className={styles.buttonIcon} aria-hidden="true" />
           </Link>
-          <Link href="/events" className={styles.heroSecondaryButton}>
-            <Users className={styles.buttonIcon} />
-            加入社区
-          </Link>
-        </div> */}
+        </div>
       </div>
     </section>
-  )
+  );
 }


### PR DESCRIPTION
## Summary

Refine the homepage hero section for a clearer, more balanced responsive layout across desktop and mobile.

## Changes

- Make the two slogan lines visually equal in size and weight.
- Highlight the parallel keywords “China”, “Global”, and “Open Source” with the existing brand color system.
- Add a lightweight decorative mark above the slogan.
- Add a low-opacity English microline below the slogan.
- Keep the primary CTA linked to `/about`.
- Make the hero responsive using the existing CSS Modules and breakpoint structure.
- Reduce excessive vertical spacing on mobile so the activity carousel appears earlier in the viewport.
- Update the hero copy for Simplified Chinese, Traditional Chinese, and English.
- Keep API, carousel data fetching, and backend behavior unchanged.

## Scope

Frontend only:

- `src/components/home/hero/Hero.tsx`
- `src/components/home/hero/Hero.module.css`
- `locales/zh-CN/common.json`
- `locales/zh-TW/common.json`
- `locales/en/common.json`

## Validation

- `npm run build` passed.
- Prettier check passed.
- Verified the layout at mobile and desktop viewport sizes.
- No API or backend changes were made.