### PR TITLE
fix(election): 候选人详情文本保留换行显示 (#30)

### DIFF
--- a/src/pages/election/index.tsx
+++ b/src/pages/election/index.tsx
@@ -200,7 +200,11 @@ export default function ElectionPage() {
                       提名理由
                     </Space>
                   ),
-                  children: <Text>{candidate.nominationReason}</Text>,
+                  children: (
+                    <Text style={{ whiteSpace: "pre-line" }}>
+                      {candidate.nominationReason}
+                    </Text>
+                  ),
                 },
                 {
                   key: "contributions",
@@ -210,7 +214,11 @@ export default function ElectionPage() {
                       上届贡献
                     </Space>
                   ),
-                  children: <Text>{candidate.previousContributions}</Text>,
+                  children: (
+                    <Text style={{ whiteSpace: "pre-line" }}>
+                      {candidate.previousContributions}
+                    </Text>
+                  ),
                 },
                 {
                   key: "platform",
@@ -220,7 +228,11 @@ export default function ElectionPage() {
                       本届主张
                     </Space>
                   ),
-                  children: <Text>{candidate.currentPlatform}</Text>,
+                  children: (
+                    <Text style={{ whiteSpace: "pre-line" }}>
+                      {candidate.currentPlatform}
+                    </Text>
+                  ),
                 },
                 {
                   key: "recommendations",
@@ -230,7 +242,11 @@ export default function ElectionPage() {
                       推荐语
                     </Space>
                   ),
-                  children: <Text>{candidate.recommendations}</Text>,
+                  children: (
+                    <Text style={{ whiteSpace: "pre-line" }}>
+                      {candidate.recommendations}
+                    </Text>
+                  ),
                 },
               ]}
             />


### PR DESCRIPTION
## Summary
- Closes #30
- 选举页候选人详情折叠面板中的「推荐语」等字段由多人填写时包含换行符，但 antd `<Text>` 默认 `white-space: normal`，换行被折叠成一行，无法区分不同推荐人
- 为提名理由、上届贡献、本届主张、推荐语四个字段的 `<Text>` 添加 `white-space: pre-line`，保留原始换行

## 修改位置
- `src/pages/election/index.tsx`：Collapse items 中四处 `<Text>` 增加 `style={{ whiteSpace: "pre-line" }}`

## 验证方式
1. 本地运行后打开 `/election`，展开候选人「推荐语」
2. 在含换行（`\n`）的推荐语数据下，每段推荐语独立成行显示（修复前所有文字挤在一行）
3. 单行数据显示效果不变

## Test plan
- [x] 本地确认推荐语元素计算样式为 `white-space: pre-line`
- [x] 使用含 `\n` 的多行样本数据验证按行渲染
- [ ] 后台录入含换行的真实推荐语后复查展示效果